### PR TITLE
Adds kivy-garden.qrcode to simple index server

### DIFF
--- a/simple/index.html
+++ b/simple/index.html
@@ -37,11 +37,12 @@
 		<p>Pip <a href="https://pip.pypa.io/en/stable/reference/pip_install/#git">git install</a>.</p>
 	</section>
 	<div class="package" >
-		<a href="/simple/kivy-garden-graph/">kivy_garden.graph</a>
-        <a href="/simple/kivy-garden-filebrowser/">kivy_garden.filebrowser</a>
         <a href="/simple/kivy-garden-collider/">kivy_garden.collider</a>
         <a href="/simple/kivy-garden-drag-n-drop/">kivy_garden.drag_n_drop</a>
+        <a href="/simple/kivy-garden-filebrowser/">kivy_garden.filebrowser</a>
+        <a href="/simple/kivy-garden-graph/">kivy_garden.graph</a>
         <a href="/simple/kivy-garden-painter/">kivy_garden.painter</a>
+        <a href="/simple/kivy-garden-qrcode/">kivy_garden.qrcode</a>
 	</div>
   </body>
 </html>

--- a/simple/kivy-garden-qrcode/index.html
+++ b/simple/kivy-garden-qrcode/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Links for kivy_garden.qrcode</title>
+  </head>
+  <body>
+    <h1>Links for kivy_garden.qrcode</h1>
+    <a href="https://github.com/kivy-garden/qrcode/archive/2019.0914.tar.gz##egg=kivy_garden.qrcode-2019.914">kivy_garden.qrcode-2019.914.tar.gz</a><br/>
+  </body>
+</html>


### PR DESCRIPTION
Also ordered simple/index.html deps alphabetically.
Tested running on local file system via:
```
pip3 install kivy_garden.qrcode== --no-index --find-links simple/kivy-garden-qrcode/
```
Output was:
```
Looking in links: simple/kivy-garden-qrcode/
Collecting kivy_garden.qrcode==
  Could not find a version that satisfies the requirement
  kivy_garden.qrcode== (from versions: 2019.914)
  No matching distribution found for kivy_garden.qrcode==
```
Note the `from versions: 2019.914` showing it was found.